### PR TITLE
fix IPloneFormGenForm interface related import AttributeError for Plone ...

### DIFF
--- a/collective/pfgpreview/configure.zcml
+++ b/collective/pfgpreview/configure.zcml
@@ -6,7 +6,7 @@
 
     <browser:page
         name="preview"
-        for="Products.PloneFormGen.interfaces.IPloneFormGenForm"
+        for="Products.PloneFormGen.interfaces.form.IPloneFormGenForm"
         class=".preview.PreviewPFGView"
         attribute="preview"
         permission="zope2.View"

--- a/collective/pfgpreview/extender.py
+++ b/collective/pfgpreview/extender.py
@@ -4,7 +4,7 @@ from archetypes.schemaextender.field import ExtensionField
 from archetypes.schemaextender.interfaces import ISchemaExtender
 from collective.pfgpreview.i18n import _
 from Products.Archetypes import atapi
-from Products.PloneFormGen.interfaces import IPloneFormGenForm
+from Products.PloneFormGen.interfaces.form import IPloneFormGenForm
 
 
 class ExStringField(ExtensionField, atapi.StringField):

--- a/collective/pfgpreview/preview.py
+++ b/collective/pfgpreview/preview.py
@@ -1,9 +1,15 @@
 from Acquisition import aq_inner
 from Products.Five import BrowserView
-from Products.PloneFormGen import implementedOrProvidedBy
+# from Products.PloneFormGen import implementedOrProvidedBy
 from Products.Archetypes.interfaces.field import IField
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
+# BBB for Z2 vs Z3 interfaces checks
+def implementedOrProvidedBy(anInterface, anObject):
+    try:
+        return anInterface.providedBy(anObject)
+    except AttributeError:
+        return anInterface.isImplementedBy(anObject)
 
 class PreviewPFGView(BrowserView):
     """ Browser view that can update and render a PFG form in some other context


### PR DESCRIPTION
I fixed the import errors I got together with Products.PloneFormGen = 1.7.12 and Plone 4.3.3 so far for me to get it to work. Please check for merging, because I am not the 100% crack for Interfaces.